### PR TITLE
[WIP] Transforms

### DIFF
--- a/willow/backends/pillow.py
+++ b/willow/backends/pillow.py
@@ -60,6 +60,21 @@ def pillow_crop(backend, left, top, right, bottom):
     backend.image = backend.image.crop((left, top, right, bottom))
 
 
+@PillowBackend.register_operation('transform')
+def pillow_transform(backend, transform):
+    Image = backend.get_pillow_image()
+
+    # We transform 4 times too big then downsize with Image.resize as that has a
+    # much better downsampling filter
+    transform = transform.resize(transform._width * 4, transform._height * 4)
+    m = transform._matrix
+    backend.image = backend.image.transform(
+        transform.size,
+        Image.AFFINE,
+        [m[0], m[1], m[4], m[2], m[3], m[5]],
+    ).resize((transform.width/4, transform.height/4), resample=Image.ANTIALIAS)
+
+
 @PillowBackend.register_operation('save_as_jpeg')
 def pillow_save_as_jpeg(backend, f, quality=85):
     backend.image.save(f, 'JPEG', quality=quality)

--- a/willow/backends/pillow.py
+++ b/willow/backends/pillow.py
@@ -64,15 +64,17 @@ def pillow_crop(backend, left, top, right, bottom):
 def pillow_transform(backend, transform):
     Image = backend.get_pillow_image()
 
+    width, height = transform.get_size()
+    m = transform.get_matrix()
+
     # We transform 4 times too big then downsize with Image.resize as that has a
     # much better downsampling filter
-    transform = transform.resize(transform._width * 4, transform._height * 4)
-    m = transform._matrix
+    transform = transform.resize(width * 4, height * 4)
     backend.image = backend.image.transform(
         transform.size,
         Image.AFFINE,
         [m[0], m[1], m[4], m[2], m[3], m[5]],
-    ).resize((transform.width/4, transform.height/4), resample=Image.ANTIALIAS)
+    ).resize((width, height), resample=Image.ANTIALIAS)
 
 
 @PillowBackend.register_operation('save_as_jpeg')

--- a/willow/transform.py
+++ b/willow/transform.py
@@ -2,13 +2,20 @@ from __future__ import division
 
 
 class Transform(object):
-    def __init__(self, width, height, matrix=None):
+    def __init__(self, width, height, scale_x=1.0, scale_y=1.0, offset_x=0.0, offset_y=0.0):
         self._width = width
         self._height = height
-        self._matrix = matrix or [1.0, 0.0, 0.0, 1.0, 0.0, 0.0]
+        self._scale_x = scale_x
+        self._scale_y = scale_y
+        self._offset_x = offset_x
+        self._offset_y = offset_y
 
     def _clone(self):
-        return type(self)(self._width, self._height, list(self._matrix))
+        return type(self)(
+            self._width, self._height,
+            self._scale_x, self._scale_y,
+            self._offset_x, self._offset_y
+        )
 
     def resize(self, width, height):
         new = self._clone()
@@ -36,18 +43,20 @@ class Transform(object):
         return self._width, self._height
 
     def get_matrix(self):
-        return self._matrix
+        return [
+            self._scale_x, 0,
+            0, self._scale_y,
+            self._offset_x, self._offset_y,
+        ]
 
     def _apply_size(self, width, height):
         self._width = width
         self._height = height
 
     def _apply_scale(self, x, y):
-        self._matrix[0] *= x
-        self._matrix[1] *= x
-        self._matrix[2] *= y
-        self._matrix[3] *= y
+        self._scale_x *= x
+        self._scale_y *= y
 
     def _apply_offset(self, x, y):
-        self._matrix[4] += self._matrix[0] * x + self._matrix[2] * y
-        self._matrix[5] += self._matrix[1] * x + self._matrix[3] * y
+        self._offset_x += self._scale_x * x
+        self._offset_y += x + self._scale_y * y

--- a/willow/transform.py
+++ b/willow/transform.py
@@ -59,4 +59,4 @@ class Transform(object):
 
     def _apply_offset(self, x, y):
         self._offset_x += self._scale_x * x
-        self._offset_y += x + self._scale_y * y
+        self._offset_y += self._scale_y * y

--- a/willow/transform.py
+++ b/willow/transform.py
@@ -32,23 +32,11 @@ class Transform(object):
         new._apply_offset(x, y)
         return new
 
-    def atob(self, x, y):
-        pass
-
-    def btoa(self, x, y):
-        pass
-
-    @property
-    def width(self):
-        return self._width
-
-    @property
-    def height(self):
-        return self._height
-
-    @property
-    def size(self):
+    def get_size(self):
         return self._width, self._height
+
+    def get_matrix(self):
+        return self._matrix
 
     def _apply_size(self, width, height):
         self._width = width

--- a/willow/transform.py
+++ b/willow/transform.py
@@ -1,0 +1,65 @@
+from __future__ import division
+
+
+class Transform(object):
+    def __init__(self, width, height, matrix=None):
+        self._width = width
+        self._height = height
+        self._matrix = matrix or [1.0, 0.0, 0.0, 1.0, 0.0, 0.0]
+
+    def _clone(self):
+        return type(self)(self._width, self._height, list(self._matrix))
+
+    def resize(self, width, height):
+        new = self._clone()
+        new._apply_size(width, height)
+        new._apply_scale(self._width / width, self._height / height)
+        return new
+
+    def crop(self, top, left, right, bottom):
+        new = self._clone()
+        new._apply_size(right - left, bottom - top)
+        new._apply_offset(left, top)
+        return new
+
+    def scale(self, x, y):
+        new = self._clone()
+        new._apply_scale(x, y)
+        return new
+
+    def offset(self, x, y):
+        new = self._clone()
+        new._apply_offset(x, y)
+        return new
+
+    def atob(self, x, y):
+        pass
+
+    def btoa(self, x, y):
+        pass
+
+    @property
+    def width(self):
+        return self._width
+
+    @property
+    def height(self):
+        return self._height
+
+    @property
+    def size(self):
+        return self._width, self._height
+
+    def _apply_size(self, width, height):
+        self._width = width
+        self._height = height
+
+    def _apply_scale(self, x, y):
+        self._matrix[0] *= x
+        self._matrix[1] *= x
+        self._matrix[2] *= y
+        self._matrix[3] *= y
+
+    def _apply_offset(self, x, y):
+        self._matrix[4] += self._matrix[0] * x + self._matrix[2] * y
+        self._matrix[5] += self._matrix[1] * x + self._matrix[3] * y


### PR DESCRIPTION
This pull request adds a new API called "Transforms"

``Transform`` objects descibe the scaling, offsetting, rotation and sizing to perform on an image. It also introduces an operation called ``transform`` that applies a ``Transform`` to an image.

Advantages:
 - Only runs one operation on the image, no matter how much cropping, resizing, rotating, etc is going on
 - ``Transform`` objects can be used for transforming points as well (in both directions). This is useful for finding where a focal point lies in a particular rendition for example (which would be handy for frontend image cropping).
 - Backends no longer need to implement ``get_size`` as this is now tracked by the ``Transform``. This also means that Wagtails image operations can be run without touching an image file
 - We now have an object to test against in Wagtails image operations (not that there's anything wrong with the way we test image operations at the moment)

Example:

```python
transform = Transform(640, 480).crop(0, 0, 100, 100).offset(0, 50).resize(50, 50)
image.transform(transform) # Transform the image

x, y = transform.atob(100, 100) # Transform coordinates from original image into rendition
x, y = transform.btoa(100, 100) # Vice versa
```

TODO:
 - [ ] Wand support
 - [ ] Implement ``atob`` and ``btoa`` methods (bonus)
 - [ ] Rotation and flipping (and possibly include a solution for #2) (bonus)
 - [ ] Implement some resizing methods on ``Image`` that use transforms (bonus)