### PR TITLE
Transparency info for a gif is a tuple, pillow expects an integer

### DIFF
--- a/willow/backends/pillow.py
+++ b/willow/backends/pillow.py
@@ -77,10 +77,7 @@ def save_as_png(backend, f):
 
 @PillowBackend.register_operation('save_as_gif')
 def save_as_gif(backend, f):
-    if 'transparency' in backend.image.info:
-        backend.image.save(f, 'GIF', transparency=backend.image.info['transparency'])
-    else:
-        backend.image.save(f, 'GIF')
+    backend.image.save(f, 'GIF')
 
 
 @PillowBackend.register_operation('has_alpha')


### PR DESCRIPTION
A Gif real `image.info` dictionary looks like:

```
{
    'version': 'GIF89a',
    'extension': ('XMP DataXMP', 814),
    'transparency': (151, 239, 255),
    'duration': 30,
    'background': 255,
    'loop': 0
}
```

However pillow expects transparency to be an integer, not a tuple of three integers. This number doesn't seem to affect the generated output, so I'm dropping transparency handling, which might not be the right thing to do.

You can easily reproduce this uploading a gif89a to wagtail under images and then listing images.

Thanks, cheers
Miguel