### PR TITLE
Retain alpha channel when resizing image.

### DIFF
--- a/willow/backends/pillow.py
+++ b/willow/backends/pillow.py
@@ -50,7 +50,7 @@ def get_size(backend):
 
 @PillowBackend.register_operation('resize')
 def resize(backend, size):
-    if backend.image.mode in ['1', 'P']:
+    if backend.image.mode in ['1']:
         backend.image = backend.image.convert('RGB')
 
     backend.image = backend.image.resize(


### PR DESCRIPTION
If the image is mode P ([8-bit pixels, mapped to any other mode using a colour palette](http://pillow.readthedocs.org/en/latest/handbook/concepts.html#modes))
the image gets converted to RGB which drops the alpha channel.

With the alpha channel lost any transparency appears as solid black.

In this pull request I'm not converting the image. Let me know if this is a bad idea.

#18