### PR TITLE
force gif storage as P mode

### DIFF
--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -44,6 +44,17 @@ class TestPillowOperations(unittest.TestCase):
 
         self.assertEqual(imghdr.what(output), 'gif')
 
+    def test_save_as_gif_converts_back_to_supported_mode(self):
+        output = io.BytesIO()
+
+        with open('tests/images/transparent.gif', 'rb') as f:
+            backend = pillow_backend.PillowBackend.from_file(f)
+            backend.image = backend.image.convert('RGB')
+        pillow_backend.save_as_gif(backend, output)
+
+        image = backend.get_pillow_image().open(output)
+        self.assertEqual(image.mode, 'P')
+
     def test_has_alpha(self):
         has_alpha = pillow_backend.has_alpha(self.backend)
         self.assertTrue(has_alpha)

--- a/willow/backends/pillow.py
+++ b/willow/backends/pillow.py
@@ -77,6 +77,9 @@ def save_as_png(backend, f):
 
 @PillowBackend.register_operation('save_as_gif')
 def save_as_gif(backend, f):
+    if backend.image.mode not in ['L', 'P']:
+        backend.image = backend.image.convert('P', palette=backend.get_pillow_image().ADAPTIVE)
+
     if 'transparency' in backend.image.info:
         backend.image.save(f, 'GIF', transparency=backend.image.info['transparency'])
     else:


### PR DESCRIPTION
This is a fix for #18 - well at least my comment on it.

The problem is that pillow and the GifImagePlugin do read gif in either L or P which expects transparency to be one dimensional 8-bits.

Therefore, upon saving we MUST enforce P mode if not given. If you, e.g., resize the image before saving, it get's converted to 3x8bit which ends up to be a python tuple instead of an int.

Disaster strikes here:

https://github.com/python-pillow/Pillow/blob/master/PIL/GifImagePlugin.py#L426

You can reproduce the bug in the given test if you revert my changes in pillow.py.

This breaks large parts of my wagtail admin, where I try to migrate an old site that is heavily dependent on gifs and the `{% image image max-130x130 %}` - tag does exactly that: resizing and saving.

I already reserved a premium place in my book of cool people if this will somehow make it into wagtail 1.2 ...