### PR TITLE
Handle all exceptions when calling _getexif

### DIFF
--- a/willow/plugins/pillow.py
+++ b/willow/plugins/pillow.py
@@ -92,7 +92,11 @@ class PillowImage(Image):
         image = self.image
 
         if hasattr(image, '_getexif'):
-            exif = image._getexif()
+            try:
+                exif = image._getexif()
+            except Exception:
+                # Blanket cover all the ways _getexif can fail in.
+                exif = None
             if exif is not None:
                 # 0x0112 = Orientation
                 orientation = exif.get(0x0112, 1)


### PR DESCRIPTION
_getexif can fail in a large number of ways and throw a variety
of exceptions. Gracefully handle all exceptions when calling it.

I ran into this issue when importing a large number of images in Wagtail causing a variety of exceptions being thrown due to slightly malformed images that otherwise displayed and scaled fine. It seems like Pillow's EXIF support still hasn't been worked on to more gracefully handle these issues, so I'd say this is the way to go.

Looking around a little, seems like easy-thumbnails had the same issue:
https://github.com/SmileyChris/easy-thumbnails/commit/a67f18e3d1dfd09cd73f77d1ac8aa9c29a00711f
