### PR TITLE
Retain alpha channel when resizing P images that have transparency

### DIFF
--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -82,7 +82,6 @@ class TestPillowOperations(unittest.TestCase):
         # Check that the alpha of pixel 1,1 is 0
         self.assertEqual(image.image.convert('RGBA').getpixel((1, 1))[3], 0)
 
-    @unittest.expectedFailure
     def test_resize_transparent_gif(self):
         with open('tests/images/transparent.gif', 'rb') as f:
             image = PillowImage.open(GIFImageFile(f))

--- a/willow/plugins/pillow.py
+++ b/willow/plugins/pillow.py
@@ -43,7 +43,10 @@ class PillowImage(Image):
         # Convert 1 and P images to RGB to improve resize quality
         # (palleted images don't get antialiased or filtered when minified)
         if self.image.mode in ['1', 'P']:
-            image = self.image.convert('RGB')
+            if self.has_alpha():
+                image = self.image.convert('RGBA')
+            else:
+                image = self.image.convert('RGB')
         else:
             image = self.image
 


### PR DESCRIPTION
Supersedes #19 

This pull request changes the behaviour of the resize operation in the pillow plugin to convert P-formatted images that have transparency to RGBA instead of RGB.

We need to convert it to RGB so we can use a better quality resize algorithm, but some P images require an alpha channel.

This fixes https://github.com/torchbox/wagtail/issues/2464