### PR TITLE
Image optimisation and progressive JPEG support

### DIFF
--- a/docs/guide/save.rst
+++ b/docs/guide/save.rst
@@ -34,16 +34,17 @@ For example, to save an image with low quality:
 Progressive JPEGs
 -----------------
 
-:meth:`~Image.save_as_jpeg` takes a ``progressive`` keyword argument, that can
-be used to make it output a progressive JPEG file:
+By default, JPEG's are saved in the same format as their source file but you
+can force Willow to always save a "progressive" JPEG file by setting the
+``progressive`` keyword argument to ``True``:
 
 .. code-block:: python
 
     with open('progressive.jpg', 'wb') as f:
         i.save_as_jpeg(f, progressive=True)
 
-Optimized images
-----------------
+Image optimisation
+------------------
 
 :meth:`~Image.save_as_jpeg` and :meth:`~Image.save_as_png` both take an
 ``optimise`` keyword that when set to true, will output an optimized image.

--- a/docs/guide/save.rst
+++ b/docs/guide/save.rst
@@ -30,3 +30,17 @@ For example, to save an image with low quality:
 
     with open('low_quality.jpg', 'wb') as f:
         i.save_as_jpeg(f, quality=40)
+
+Optimized images
+----------------
+
+:meth:`~Image.save_as_jpeg` and :meth:`~Image.save_as_png` both take an
+``optimise`` keyword that when set to true, will output an optimized image.
+
+.. code-block:: python
+
+    with open('optimized.jpg', 'wb') as f:
+        i.save_as_jpeg(f, optimize=True)
+
+This feature is currently only supported in the Pillow backend, if you use Wand
+this argument will be ignored.

--- a/docs/guide/save.rst
+++ b/docs/guide/save.rst
@@ -31,6 +31,17 @@ For example, to save an image with low quality:
     with open('low_quality.jpg', 'wb') as f:
         i.save_as_jpeg(f, quality=40)
 
+Progressive JPEGs
+-----------------
+
+:meth:`~Image.save_as_jpeg` takes a ``progressive`` keyword argument, that can
+be used to make it output a progressive JPEG file:
+
+.. code-block:: python
+
+    with open('progressive.jpg', 'wb') as f:
+        i.save_as_jpeg(f, progressive=True)
+
 Optimized images
 ----------------
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -186,7 +186,7 @@ Here's a full list of operations provided by Willow out of the box:
 
         faces = image.detect_faces()
 
-.. method:: save_as_jpeg(file, quality=85)
+.. method:: save_as_jpeg(file, quality=85, optimize=False)
 
     (Pillow/Wand only)
 
@@ -199,7 +199,7 @@ Here's a full list of operations provided by Willow out of the box:
         with open('out.jpg', 'wb') as f:
             image.save_as_jpeg(f)
 
-.. method:: save_as_png(file)
+.. method:: save_as_png(file, optimize=False)
 
     (Pillow/Wand only)
 

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -2,6 +2,8 @@ import unittest
 import io
 import imghdr
 
+from PIL import Image as PILImage
+
 from willow.image import JPEGImageFile, PNGImageFile, GIFImageFile
 from willow.plugins.pillow import _PIL_Image, PillowImage
 
@@ -39,6 +41,11 @@ class TestPillowOperations(unittest.TestCase):
 
         # Optimised image must be smaller than unoptimised image
         self.assertTrue(optimised.f.tell() < unoptimised.f.tell())
+
+    def test_save_as_jpeg_progressive(self):
+        image = self.image.save_as_jpeg(io.BytesIO(), progressive=True)
+
+        self.assertTrue(PILImage.open(image.f).info['progressive'])
 
     def test_save_as_png(self):
         output = io.BytesIO()

--- a/tests/test_pillow.py
+++ b/tests/test_pillow.py
@@ -33,6 +33,13 @@ class TestPillowOperations(unittest.TestCase):
         self.assertIsInstance(return_value, JPEGImageFile)
         self.assertEqual(return_value.f, output)
 
+    def test_save_as_jpeg_optimised(self):
+        unoptimised = self.image.save_as_jpeg(io.BytesIO())
+        optimised = self.image.save_as_jpeg(io.BytesIO(), optimize=True)
+
+        # Optimised image must be smaller than unoptimised image
+        self.assertTrue(optimised.f.tell() < unoptimised.f.tell())
+
     def test_save_as_png(self):
         output = io.BytesIO()
         return_value = self.image.save_as_png(output)
@@ -41,6 +48,13 @@ class TestPillowOperations(unittest.TestCase):
         self.assertEqual(imghdr.what(output), 'png')
         self.assertIsInstance(return_value, PNGImageFile)
         self.assertEqual(return_value.f, output)
+
+    def test_save_as_png_optimised(self):
+        unoptimised = self.image.save_as_png(io.BytesIO())
+        optimised = self.image.save_as_png(io.BytesIO(), optimize=True)
+
+        # Optimised image must be smaller than unoptimised image
+        self.assertTrue(optimised.f.tell() < unoptimised.f.tell())
 
     def test_save_as_gif(self):
         output = io.BytesIO()

--- a/tests/test_wand.py
+++ b/tests/test_wand.py
@@ -35,6 +35,14 @@ class TestWandOperations(unittest.TestCase):
         self.assertIsInstance(return_value, JPEGImageFile)
         self.assertEqual(return_value.f, output)
 
+    @unittest.expectedFailure
+    def test_save_as_jpeg_optimised(self):
+        unoptimised = self.image.save_as_jpeg(io.BytesIO())
+        optimised = self.image.save_as_jpeg(io.BytesIO(), optimize=True)
+
+        # Optimised image must be smaller than unoptimised image
+        self.assertTrue(optimised.f.tell() < unoptimised.f.tell())
+
     def test_save_as_png(self):
         output = io.BytesIO()
         return_value = self.image.save_as_png(output)
@@ -43,6 +51,14 @@ class TestWandOperations(unittest.TestCase):
         self.assertEqual(imghdr.what(output), 'png')
         self.assertIsInstance(return_value, PNGImageFile)
         self.assertEqual(return_value.f, output)
+
+    @unittest.expectedFailure
+    def test_save_as_png_optimised(self):
+        unoptimised = self.image.save_as_png(io.BytesIO())
+        optimised = self.image.save_as_png(io.BytesIO(), optimize=True)
+
+        # Optimised image must be smaller than unoptimised image
+        self.assertTrue(optimised.f.tell() < unoptimised.f.tell())
 
     def test_save_as_gif(self):
         output = io.BytesIO()

--- a/tests/test_wand.py
+++ b/tests/test_wand.py
@@ -4,6 +4,8 @@ import imghdr
 
 from wand.color import Color
 
+from PIL import Image as PILImage
+
 from willow.image import JPEGImageFile, PNGImageFile, GIFImageFile
 from willow.plugins.wand import _wand_image, WandImage
 
@@ -42,6 +44,11 @@ class TestWandOperations(unittest.TestCase):
 
         # Optimised image must be smaller than unoptimised image
         self.assertTrue(optimised.f.tell() < unoptimised.f.tell())
+
+    def test_save_as_jpeg_progressive(self):
+        image = self.image.save_as_jpeg(io.BytesIO(), progressive=True)
+
+        self.assertTrue(PILImage.open(image.f).info['progressive'])
 
     def test_save_as_png(self):
         output = io.BytesIO()

--- a/willow/plugins/pillow.py
+++ b/willow/plugins/pillow.py
@@ -57,18 +57,28 @@ class PillowImage(Image):
         return PillowImage(self.image.crop(rect))
 
     @Image.operation
-    def save_as_jpeg(self, f, quality=85):
+    def save_as_jpeg(self, f, quality=85, optimize=False):
         if self.image.mode in ['1', 'P']:
             image = self.image.convert('RGB')
         else:
             image = self.image
 
-        image.save(f, 'JPEG', quality=quality)
+        # Pillow only checks presence of optimize kwarg, not its value
+        kwargs = {}
+        if optimize:
+            kwargs['optimize'] = True
+
+        image.save(f, 'JPEG', quality=quality, **kwargs)
         return JPEGImageFile(f)
 
     @Image.operation
-    def save_as_png(self, f):
-        self.image.save(f, 'PNG')
+    def save_as_png(self, f, optimize=False):
+        # Pillow only checks presence of optimize kwarg, not its value
+        kwargs = {}
+        if optimize:
+            kwargs['optimize'] = True
+
+        self.image.save(f, 'PNG', **kwargs)
         return PNGImageFile(f)
 
     @Image.operation

--- a/willow/plugins/pillow.py
+++ b/willow/plugins/pillow.py
@@ -57,7 +57,7 @@ class PillowImage(Image):
         return PillowImage(self.image.crop(rect))
 
     @Image.operation
-    def save_as_jpeg(self, f, quality=85, optimize=False):
+    def save_as_jpeg(self, f, quality=85, optimize=False, progressive=False):
         if self.image.mode in ['1', 'P']:
             image = self.image.convert('RGB')
         else:
@@ -67,6 +67,8 @@ class PillowImage(Image):
         kwargs = {}
         if optimize:
             kwargs['optimize'] = True
+        if progressive:
+            kwargs['progressive'] = True
 
         image.save(f, 'JPEG', quality=quality, **kwargs)
         return JPEGImageFile(f)

--- a/willow/plugins/wand.py
+++ b/willow/plugins/wand.py
@@ -60,8 +60,8 @@ class WandImage(Image):
         return clone
 
     @Image.operation
-    def save_as_jpeg(self, f, quality=85, optimize=False):
-        with self.image.convert('jpeg') as converted:
+    def save_as_jpeg(self, f, quality=85, optimize=False, progressive=False):
+        with self.image.convert('pjpeg' if progressive else 'jpeg') as converted:
             converted.compression_quality = quality
             converted.save(file=f)
 

--- a/willow/plugins/wand.py
+++ b/willow/plugins/wand.py
@@ -60,7 +60,7 @@ class WandImage(Image):
         return clone
 
     @Image.operation
-    def save_as_jpeg(self, f, quality=85):
+    def save_as_jpeg(self, f, quality=85, optimize=False):
         with self.image.convert('jpeg') as converted:
             converted.compression_quality = quality
             converted.save(file=f)
@@ -68,7 +68,7 @@ class WandImage(Image):
         return JPEGImageFile(f)
 
     @Image.operation
-    def save_as_png(self, f):
+    def save_as_png(self, f, optimize=False):
         with self.image.convert('png') as converted:
             converted.save(file=f)
 


### PR DESCRIPTION
Fixes #10 

This PR implements image optimisation using Pillows ``optimize`` feature. It also implements a switch to convert JPEG files to progressive which should improve user experience when used for images on the web.

We may still want to support external image optimisers as I think they probably have a few more tricks than Pillow does, but this PR is definitely an improvement.